### PR TITLE
Fix Vite setup and clarify usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # ciftlik_vergi_simulat-or
+
+This project provides a simple Vite + React setup for a farm tax simulator component.
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the dev server:
+   ```bash
+   npm run dev
+   ```
+
+## Production build
+
+Run the build command to generate the production-ready assets:
+```bash
+npm run build
+```

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "tax",
     "simulator"
   ],
+  "devDependencies": {
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^4.2.0"
+  },
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/VergiSimulasyonuDetay.jsx
+++ b/src/VergiSimulasyonuDetay.jsx
@@ -1,0 +1,2 @@
+export { default } from "./simulator.jsx";
+export * from "./simulator.jsx";


### PR DESCRIPTION
## Summary
- document how to build and develop the project
- add missing devDependencies for Vite
- restore `VergiSimulasyonuDetay.jsx` export helper

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68587e20542c832e859d81ab615e5ba6