### PR TITLE
Restore build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# ciftlik_vergi_simulat-or
+
+This project provides a simple React component for a farm tax simulator.
+
+## Development
+
+1. Install dependencies (none are required but this step will create `node_modules`):
+   ```bash
+   npm install
+   ```
+2. Open `dist/index.html` in a browser after running the build step.
+
+## Production build
+
+Run the build command to generate the distributable files:
+```bash
+npm run build
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ciftlik-vergi-simulator",
+  "version": "1.0.0",
+  "description": "Farm tax simulator React component",
+  "main": "src/simulator.jsx",
+  "type": "module",
+  "scripts": {
+    "build": "mkdir -p dist && cp index.html dist/ && cp -r src dist/"
+  },
+  "keywords": [
+    "react",
+    "farm",
+    "tax",
+    "simulator"
+  ],
+  "dependencies": {},
+  "author": "",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- revive README docs
- add `npm run build` script back to `package.json`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685880ac613c832ea314d5f6f8914e0d