### PR TITLE
Load React via CDN and drop module imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project provides a simple React component for a farm tax simulator.
    ```bash
    npm install
    ```
-2. Open `dist/index.html` in a browser after running the build step.
+2. Either open `index.html` directly or run the build step and open `dist/index.html` in a browser. React and Babel are loaded from a CDN so no bundler is required.
 
 ## Production build
 

--- a/index.html
+++ b/index.html
@@ -4,9 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vergi Simülasyonu</title>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="text/babel" src="./src/simulator.jsx"></script>
+    <script type="text/babel" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import VergiSimulasyonuTablosu from './VergiSimulasyonuDetay.jsx';
+// React and ReactDOM are loaded globally via CDN
+// VergiSimulasyonuTablosu is defined in simulator.jsx
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/simulator.jsx
+++ b/src/simulator.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+// React is loaded globally via CDN
+const { useState } = React;
 
 const aciklamalar = {
   girisBedeli: "Yatırımcıdan alınan hayvan başı giriş bedeli (KDV hariç)",
@@ -101,7 +102,7 @@ function hesaplaYillikVeri(veri, hayvanSayisi, tip) {
   };
 }
 
-export default function VergiSimulasyonuTablosu() {
+function VergiSimulasyonuTablosu() {
   const [veri, setVeri] = useState(varsayilanVeri);
   const yatirimci = hesaplaYillikVeri(veri, veri.inekSayisiYatirimci, "yatirimci");
   const sirket = hesaplaYillikVeri(veri, veri.inekSayisiSirket, "sirket");
@@ -178,4 +179,14 @@ export default function VergiSimulasyonuTablosu() {
   );
 }
 
-export { varsayilanVeri, hesaplaYillikVeri };
+// Expose functions for Node or browser environments
+if (typeof module !== 'undefined') {
+  module.exports = { VergiSimulasyonuTablosu, varsayilanVeri, hesaplaYillikVeri };
+}
+
+// Expose component globally for the browser build
+if (typeof window !== 'undefined') {
+  window.VergiSimulasyonuTablosu = VergiSimulasyonuTablosu;
+  window.varsayilanVeri = varsayilanVeri;
+  window.hesaplaYillikVeri = hesaplaYillikVeri;
+}


### PR DESCRIPTION
## Summary
- load React and ReactDOM via UMD CDN scripts
- compile JSX files in the browser with Babel without module imports
- expose simulator component globally for the browser build
- remove ES module exports so the browser version runs
- clarify instructions for running the example

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68588be88d9c832eaf8d1260bb395de0